### PR TITLE
Using build script output dir.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,40 @@
-use std::{path::Path, process::Command};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn recursive_hardlink(from: &Path, to: &Path) {
+    let mut stack = vec![from.to_path_buf()];
+    while let Some(curr_from) = stack.pop() {
+        let to = to.join(curr_from.strip_prefix(from).unwrap());
+        eprintln!("Linking {:?} to {:?}", curr_from, to);
+        if curr_from.is_dir() {
+            std::fs::create_dir(&to).expect("Failed to create directory");
+            for entry in curr_from.read_dir().unwrap() {
+                stack.push(entry.unwrap().path());
+            }
+        } else {
+            std::fs::hard_link(&curr_from, &to).expect("Failed to hard link file");
+        }
+    }
+}
 
 fn main() {
-    // Run make test in the zkevm-prover directory
-    let zkevm_prover_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("externals/zkevm-prover");
+    let externals_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("externals");
+    // Configure build.rs rerun. Lossy conversion to str won't cut it here...
+    println!("cargo:rerun-if-changed={}", externals_dir.to_str().unwrap());
 
+    // Clear cargo's OUT_DIR
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    eprintln!("Clearing OUT_DIR: {:?}", out_dir);
+    std::fs::remove_dir_all(&out_dir).unwrap();
+
+    // Hardlink all files of the externals directory to OUT_DIR
+    recursive_hardlink(&externals_dir, &out_dir);
+
+    // Run make test in the zkevm-prover directory
+    let zkevm_prover_dir = out_dir.join("zkevm-prover");
     eprintln!(
         "Running make test in zkevm-prover directory: {}",
         zkevm_prover_dir.display()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub struct OutputFiles {
 }
 
 const MAX_NODE_MEM: u32 = 1024 * 16;
-const CRATE_DIR: &str = env!("CARGO_MANIFEST_DIR");
+const EXTERNALS_DIR: &str = env!("OUT_DIR");
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -72,11 +72,11 @@ pub fn generate_proof(
     commits_bin: &Path,
     output_dir: &Path,
 ) -> Result<OutputFiles, Error> {
-    let crate_dir = Path::new(CRATE_DIR);
-    let pil_stark_root = crate_dir.join("externals/pil-stark");
+    let externals_dir = Path::new(EXTERNALS_DIR);
+    let pil_stark_root = externals_dir.join("pil-stark");
     let pil_stark_src = pil_stark_root.join("src");
 
-    let zkevm_prover_dir = crate_dir.join("externals/zkevm-prover");
+    let zkevm_prover_dir = externals_dir.join("zkevm-prover");
 
     let verification_key_json = output_dir.join("verification_key.json");
     let consttree_bin = output_dir.join("consttree.bin");
@@ -163,7 +163,7 @@ pub fn generate_proof(
                 "-o",
             ])
             .arg(&dynamic_chelpers)
-            .arg(crate_dir.join("externals/zkevm-prover/test/examples/dynamic_chelpers.cpp"))
+            .arg(externals_dir.join("zkevm-prover/test/examples/dynamic_chelpers.cpp"))
             .arg(format!("-I{}", chelpers_header_dir.to_str().unwrap()))
             .args(
                 [
@@ -217,8 +217,8 @@ pub fn verify_proof(
     proof_json: &Path,
     publics_json: &Path,
 ) -> Result<(), Error> {
-    let crate_dir = Path::new(CRATE_DIR);
-    let pil_stark_root = crate_dir.join("externals/pil-stark");
+    let externals_dir = Path::new(EXTERNALS_DIR);
+    let pil_stark_root = externals_dir.join("pil-stark");
     let pil_stark_src = pil_stark_root.join("src");
 
     log::info!("Verifying proof...");
@@ -278,8 +278,7 @@ mod tests {
     }
 
     fn prove_and_verify(output_dir: &Path) {
-        let crate_dir = Path::new(CRATE_DIR);
-        let test_data_dir = crate_dir.join("test-data");
+        let test_data_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("test-data");
 
         let pil_json = test_data_dir.join("constraints.json");
         let starkstruct_json = test_data_dir.join("starkstruct.json");


### PR DESCRIPTION
`build.rs` should not touch the source directories. Instead, everything is hardlinked to `OUT_DIR` and built and executed from there.